### PR TITLE
Tile Data cleanup

### DIFF
--- a/app/src/app/query/[lngLat]/query-card/feature-info.tsx
+++ b/app/src/app/query/[lngLat]/query-card/feature-info.tsx
@@ -7,28 +7,29 @@ export const FeatureInfo = ({
   feature: MapboxGeoJSONFeature;
   className?: string;
 }) => {
-  // @ts-expect-error
-  const { NAME, ...propertiesToDisplay } = feature.properties;
-  return (
-    <div className={className}>
-      <div className="overflow-x-auto">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>Property</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(propertiesToDisplay).map(([p, v]) => (
-              <tr key={p} className="hover">
-                <td>{p}</td>
-                <td>{v}</td>
+  if (feature.properties) {
+    return (
+      <div className={className}>
+        <div className="overflow-x-auto">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Property</th>
+                <th>Value</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {Object.entries(feature.properties).map(([p, v]) => (
+                <tr key={p} className="hover">
+                  <td>{p}</td>
+                  <td>{v}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+  return <></>;
 };

--- a/app/src/app/query/[lngLat]/query-card/features.tsx
+++ b/app/src/app/query/[lngLat]/query-card/features.tsx
@@ -36,8 +36,8 @@ export const Features = ({
   }, [scrollPosition]);
 
   return (
-    <div>
-      <div className="pb-2">
+    <div className="flex flex-col overflow-hidden">
+      <div className="pb-2 border-b border-b-base-200">
         <div className="join flex items-center">
           <button
             className="join-item btn"
@@ -53,6 +53,7 @@ export const Features = ({
               currentFeature.properties?.NAME?.trim() ||
               currentFeature.properties?.description?.trim() ||
               currentFeature.properties?.title?.trim() ||
+              currentFeature.properties?.adm_manage?.trim() ||
               "Unknown"}
           </div>
           <button
@@ -66,16 +67,14 @@ export const Features = ({
           </button>
         </div>
       </div>
-      <div className="overflow-hidden scroll-smooth" ref={containerEl}>
-        <div className="flex">
-          {features.map((feature, i) => (
-            <FeatureInfo
-              feature={feature}
-              key={feature.id ?? i}
-              className="min-w-full"
-            />
-          ))}
-        </div>
+      <div className="overflow-hidden scroll-smooth flex" ref={containerEl}>
+        {features.map((feature, i) => (
+          <FeatureInfo
+            feature={feature}
+            key={feature.id ?? i}
+            className="min-w-full overflow-y-scroll"
+          />
+        ))}
       </div>
     </div>
   );

--- a/app/src/components/card/index.tsx
+++ b/app/src/components/card/index.tsx
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 
 const card = cva(
   [
-    "card absolute top-0 pb-8 pt-4 px-4 w-1/4 m-0 drop-shadow-hover gap-4 pointer-events-auto",
+    "card absolute top-0 pb-8 pt-4 px-4 w-1/4 m-0 drop-shadow-hover gap-4 pointer-events-auto max-h-full flex flex-col bg-base-100",
   ],
   {
     variants: {

--- a/data/src/constants.ts
+++ b/data/src/constants.ts
@@ -3,3 +3,19 @@ export const LCMD_QUERY_ENDPOINT =
 
 export const LCPL_QUERY_ENDPOINT =
   "https://services1.arcgis.com/38PTfoP8IjlBsxZN/arcgis/rest/services/Federal_Lands_ALL_Lake/FeatureServer/0/query";
+
+export const TAX_PARCEL_PROPERTIES = [
+  "NAME",
+  "ACRES",
+  "ACTUAL_VAL",
+  "ADDRESS1",
+  "ADDRESS2",
+  "ASSESSED_V",
+  "LEGAL",
+  "LEGAL_1",
+  "MILL_LEVY",
+  "STREETNO",
+  "STREETNAME",
+];
+
+export const PUBLIC_LAND_PROPERTIES = ["adm_manage", "GIS_acres"];

--- a/data/src/generate-data.ts
+++ b/data/src/generate-data.ts
@@ -1,4 +1,8 @@
-import { getFullGeoJson } from "./internal";
+import {
+  PUBLIC_LAND_PROPERTIES,
+  TAX_PARCEL_PROPERTIES,
+  getFullGeoJson,
+} from "./internal";
 import { promises } from "node:fs";
 import { LCMD_QUERY_ENDPOINT, LCPL_QUERY_ENDPOINT } from "./internal";
 import { layerifyByOwner, layerifyPublicLand } from "./internal";
@@ -13,7 +17,7 @@ export const generateData = () => {
       Promise.all([
         getFullGeoJson(
           LCMD_QUERY_ENDPOINT,
-          "NAME,MILL_LEVY,ASSESSED_V,FID"
+          TAX_PARCEL_PROPERTIES.join(",")
         ).then((data) => {
           const layerStyles = layerifyByOwner(data);
           console.log(`Writing data for ${LCMD_QUERY_ENDPOINT}`);
@@ -25,7 +29,10 @@ export const generateData = () => {
             writeFile("generated/tax_parcels.json", JSON.stringify(data)),
           ]);
         }),
-        getFullGeoJson(LCPL_QUERY_ENDPOINT, "adm_manage,FID").then((data) => {
+        getFullGeoJson(
+          LCPL_QUERY_ENDPOINT,
+          PUBLIC_LAND_PROPERTIES.join(",")
+        ).then((data) => {
           const layerStyles = layerifyPublicLand();
           console.log(`Writing data for ${LCPL_QUERY_ENDPOINT}`);
           return Promise.all([

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "app:dev": "yarn workspace @lc-maptools/app dev",
     "ci:install-tippecanoe": "./ci-install-tippecanoe.sh",
     "dev": "concurrently -c blue,magenta -n app,tiles \"yarn app:dev\" \"yarn tiles:serve\"",
-    "dev:start": "yarn generate:all && yarn dev",
+    "dev:start": "yarn generate && yarn dev",
     "generate:data": "yarn workspace @lc-maptools/data generate",
     "generate:tiles": "yarn workspace @lc-maptools/tile-server generate",
-    "generate:all": "yarn generate:data && yarn generate:tiles",
+    "generate": "yarn generate:data && yarn generate:tiles",
     "tiles:serve": "yarn workspace @lc-maptools/tile-server serve"
   },
   "dependencies": {

--- a/tile-server/generate-tiles.sh
+++ b/tile-server/generate-tiles.sh
@@ -5,8 +5,13 @@
 # -pt - don't combine tiny polygons
 # -pC - uncompressed
 # -ai - generate IDs if missing
+# -pk - no size limit
+# -pS - only simplify below maxzoom
+# -pg - no tilestats in metadata (used for mapbox tile api?)
+# -x - exclude property
 ###
-OPTIONS='-pt -z17 -pC -ai -pS'
+EXCLUDE='-x stroke-width -x stroke-opacity -x fill -x stroke -x class -x gpstype -x pattern -x fill-opacity -x creator'
+OPTIONS="-pt -z16 -pC -ai -pk -pg -pS $EXCLUDE"
 
 echo "Generating tiles from JSON..."
 


### PR DESCRIPTION
- Pare down data from Reroutes
- Select only needed data from tax parcels, public land
- Unrestrict tile size to include data
- Query card layout scrolling due to increased fields